### PR TITLE
Implements priority pattern "scene then entity then default" for RelationshipBehavior on apply_scene

### DIFF
--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -900,8 +900,8 @@
 pub mod prelude {
     pub use crate::{
         bsn, bsn_list, on, template_value, CommandsSceneExt, EntityCommandsSceneExt,
-        EntityWorldMutSceneExt, PatchFromTemplate, PatchTemplate, RelationshipBehavior, Scene, SceneComponent, SceneList,
-        ScenePatchInstance, SpawnListSystem, SpawnSystem, WorldSceneExt,
+        EntityWorldMutSceneExt, PatchFromTemplate, PatchTemplate, RelationshipBehavior, Scene,
+        SceneComponent, SceneList, ScenePatchInstance, SpawnListSystem, SpawnSystem, WorldSceneExt,
     };
 }
 

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -197,8 +197,6 @@ pub struct ResolvedScene {
     /// A list of all [`SceneEntityReference`] values associated with this entity. There can be more than one if this scene uses
     /// "flattened" caching.
     pub entity_references: Vec<SceneEntityReference>,
-    /// The [`RelationshipBehavior`] specified by this scene, if any.
-    pub(crate) relationship_behavior: Option<RelationshipBehavior>,
 }
 
 impl core::fmt::Debug for ResolvedScene {
@@ -245,7 +243,7 @@ impl ResolvedScene {
         writer_ops: impl FnOnce(&mut TemplateContext, &mut BundleWriter),
     ) -> Result<(), ApplySceneError> {
         let relationship_behavior = self
-            .relationship_behavior
+            .relationship_behavior_from_scene(context)
             .or_else(|| context.entity.get::<RelationshipBehavior>().copied())
             .unwrap_or_default();
         let mut bundle_writer = bundle_scratch.writer();
@@ -322,6 +320,28 @@ impl ResolvedScene {
         };
 
         Ok(())
+    }
+
+    /// Resolves [`RelationshipBehavior`] from this scene's templates, if present.
+    fn relationship_behavior_from_scene(
+        &self,
+        context: &mut TemplateContext,
+    ) -> Option<RelationshipBehavior> {
+        if let Some(behavior) = self.direct_component_template::<RelationshipBehavior>() {
+            return Some(behavior);
+        }
+
+        type BehaviorTemplate = <RelationshipBehavior as FromTemplate>::Template;
+        let index = self.template_indices.get(&TypeId::of::<BehaviorTemplate>())?;
+        let template = self.component_templates.get(*index)?.as_ref();
+        let behavior_template = (template as &dyn Any).downcast_ref::<BehaviorTemplate>()?;
+        behavior_template.build_template(context).ok()
+    }
+
+    fn direct_component_template<C: Component + Copy>(&self) -> Option<C> {
+        let index = self.template_indices.get(&TypeId::of::<C>())?;
+        let template = self.component_templates.get(*index)?.as_ref();
+        (template as &dyn Any).downcast_ref::<C>().copied()
     }
 
     fn insert_relationship_targets(
@@ -457,47 +477,12 @@ impl ResolvedScene {
         &'a mut self,
         context: &mut ResolveContext,
     ) -> &'a mut T {
-        let type_id = TypeId::of::<T>();
-        let index = *self.template_indices.entry(type_id).or_insert_with(|| {
-            let index = self.component_templates.len();
-            let value = if let Some(cached_patch) = &mut context.cached
-                && let Some(resolved_cached) = &cached_patch.resolved
-                && let Some(cached_template) = resolved_cached.scene.get_direct_erased_template(type_id)
-            {
-                self.cached
-                    .as_mut()
-                    .unwrap()
-                    .duplicate_templates
-                    .insert(type_id);
-                cached_template.clone_template()
-            } else {
-                Box::new(T::default())
-            };
-            self.component_templates.push(value);
-            index
-        });
-
-        let behavior = {
-            let template = (&mut **self.component_templates.get_mut(index).unwrap() as &mut dyn Any)
-                .downcast_mut::<T>()
-                .unwrap();
-            if type_id == TypeId::of::<RelationshipBehavior>() {
-                Some(
-                    *(&*template as &dyn Any)
-                        .downcast_ref::<RelationshipBehavior>()
-                        .unwrap(),
-                )
-            } else {
-                None
-            }
-        };
-        if let Some(behavior) = behavior {
-            self.relationship_behavior = Some(behavior);
-        }
-
-        (&mut **self.component_templates.get_mut(index).unwrap() as &mut dyn Any)
+        (self.get_or_insert_erased_template(context, TypeId::of::<T>(), || Box::new(T::default()))
+            as &mut dyn Any)
+            // PERF: this could be unchecked, given that we control what is stored here
+            // The method isn't stable yet, and it would require making get_or_insert_erased_template unsafe
             .downcast_mut()
-            .unwrap()
+            .expect("template type mismatch in ResolvedScene::get_or_insert_template")
     }
 
     /// This will get the [`ErasedComponentTemplate`] for the given [`TypeId`], if it already exists in this [`ResolvedScene`]. If it doesn't exist,

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     entity::Entity,
     error::{BevyError, Result},
     relationship::{Relationship, RelationshipSourceCollection, RelationshipTarget},
-    template::{SceneEntityReference, SceneEntityReferences, Template, TemplateContext},
+    template::{FromTemplate, SceneEntityReference, SceneEntityReferences, Template, TemplateContext},
     world::{EntityWorldMut, World},
 };
 use bevy_platform::collections::HashSet;
@@ -16,11 +16,13 @@ use thiserror::Error;
 
 /// Controls how scene application handles existing [`RelationshipTarget`] components on the entity.
 ///
-/// Insert this component on an entity before calling [`EntityWorldMutSceneExt::apply_scene`] to
-/// retain and extend existing related entities instead of replacing them.
+/// When applying a scene, the behavior is resolved in this order:
+/// 1. A [`RelationshipBehavior`] component included in the scene
+/// 2. A [`RelationshipBehavior`] component on the entity being applied to
+/// 3. [`RelationshipBehavior::Overwrite`]
 ///
 /// [`EntityWorldMutSceneExt::apply_scene`]: crate::EntityWorldMutSceneExt::apply_scene
-#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, FromTemplate)]
 pub enum RelationshipBehavior {
     /// Replaces existing [`RelationshipTarget`] components with new collections for the scene's related entities.
     #[default]
@@ -195,6 +197,8 @@ pub struct ResolvedScene {
     /// A list of all [`SceneEntityReference`] values associated with this entity. There can be more than one if this scene uses
     /// "flattened" caching.
     pub entity_references: Vec<SceneEntityReference>,
+    /// The [`RelationshipBehavior`] specified by this scene, if any.
+    pub(crate) relationship_behavior: Option<RelationshipBehavior>,
 }
 
 impl core::fmt::Debug for ResolvedScene {
@@ -240,10 +244,9 @@ impl ResolvedScene {
         bundle_scratch: &mut BundleScratch,
         writer_ops: impl FnOnce(&mut TemplateContext, &mut BundleWriter),
     ) -> Result<(), ApplySceneError> {
-        let relationship_behavior = context
-            .entity
-            .get::<RelationshipBehavior>()
-            .copied()
+        let relationship_behavior = self
+            .relationship_behavior
+            .or_else(|| context.entity.get::<RelationshipBehavior>().copied())
             .unwrap_or_default();
         let mut bundle_writer = bundle_scratch.writer();
         for entity_reference in self.entity_references.iter().copied() {
@@ -454,10 +457,45 @@ impl ResolvedScene {
         &'a mut self,
         context: &mut ResolveContext,
     ) -> &'a mut T {
-        (self.get_or_insert_erased_template(context, TypeId::of::<T>(), || Box::new(T::default()))
-            as &mut dyn Any)
-            // PERF: this could be unchecked, given that we control what is stored here
-            // The method isn't stable yet, and it would require making get_or_insert_erased_template unsafe
+        let type_id = TypeId::of::<T>();
+        let index = *self.template_indices.entry(type_id).or_insert_with(|| {
+            let index = self.component_templates.len();
+            let value = if let Some(cached_patch) = &mut context.cached
+                && let Some(resolved_cached) = &cached_patch.resolved
+                && let Some(cached_template) = resolved_cached.scene.get_direct_erased_template(type_id)
+            {
+                self.cached
+                    .as_mut()
+                    .unwrap()
+                    .duplicate_templates
+                    .insert(type_id);
+                cached_template.clone_template()
+            } else {
+                Box::new(T::default())
+            };
+            self.component_templates.push(value);
+            index
+        });
+
+        let behavior = {
+            let template = (&mut **self.component_templates.get_mut(index).unwrap() as &mut dyn Any)
+                .downcast_mut::<T>()
+                .unwrap();
+            if type_id == TypeId::of::<RelationshipBehavior>() {
+                Some(
+                    *(&*template as &dyn Any)
+                        .downcast_ref::<RelationshipBehavior>()
+                        .unwrap(),
+                )
+            } else {
+                None
+            }
+        };
+        if let Some(behavior) = behavior {
+            self.relationship_behavior = Some(behavior);
+        }
+
+        (&mut **self.component_templates.get_mut(index).unwrap() as &mut dyn Any)
             .downcast_mut()
             .unwrap()
     }

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -6,7 +6,9 @@ use bevy_ecs::{
     entity::Entity,
     error::{BevyError, Result},
     relationship::{Relationship, RelationshipSourceCollection, RelationshipTarget},
-    template::{FromTemplate, SceneEntityReference, SceneEntityReferences, Template, TemplateContext},
+    template::{
+        FromTemplate, SceneEntityReference, SceneEntityReferences, Template, TemplateContext,
+    },
     world::{EntityWorldMut, World},
 };
 use bevy_platform::collections::HashSet;
@@ -332,7 +334,9 @@ impl ResolvedScene {
         }
 
         type BehaviorTemplate = <RelationshipBehavior as FromTemplate>::Template;
-        let index = self.template_indices.get(&TypeId::of::<BehaviorTemplate>())?;
+        let index = self
+            .template_indices
+            .get(&TypeId::of::<BehaviorTemplate>())?;
         let template = self.component_templates.get(*index)?.as_ref();
         let behavior_template = (template as &dyn Any).downcast_ref::<BehaviorTemplate>()?;
         behavior_template.build_template(context).ok()

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -482,7 +482,7 @@ impl ResolvedScene {
             // PERF: this could be unchecked, given that we control what is stored here
             // The method isn't stable yet, and it would require making get_or_insert_erased_template unsafe
             .downcast_mut()
-            .expect("template type mismatch in ResolvedScene::get_or_insert_template")
+            .unwrap()
     }
 
     /// This will get the [`ErasedComponentTemplate`] for the given [`TypeId`], if it already exists in this [`ResolvedScene`]. If it doesn't exist,

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,4 +1,4 @@
-use crate::{CachedSceneError, ResolvedScene, SceneList, ScenePatch};
+use crate::{CachedSceneError, RelationshipBehavior, ResolvedScene, SceneList, ScenePatch};
 use bevy_asset::{Asset, AssetPath, AssetServer, Assets};
 use bevy_ecs::{
     bundle::Bundle,
@@ -10,7 +10,7 @@ use bevy_ecs::{
     system::IntoObserverSystem,
     template::{FnTemplate, FromTemplate, SceneEntityReference, Template, TemplateContext},
 };
-use core::{any::TypeId, marker::PhantomData};
+use core::{any::{Any, TypeId}, marker::PhantomData};
 use thiserror::Error;
 use variadics_please::all_tuples;
 
@@ -344,6 +344,13 @@ impl<
     ) -> Result<(), ResolveSceneError> {
         let template = scene.get_or_insert_template::<T>(context);
         (self.0)(template, context);
+        if TypeId::of::<T>() == TypeId::of::<RelationshipBehavior>() {
+            scene.relationship_behavior = Some(
+                *(&*template as &dyn Any)
+                    .downcast_ref::<RelationshipBehavior>()
+                    .unwrap(),
+            );
+        }
         Ok(())
     }
 }

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,4 +1,4 @@
-use crate::{CachedSceneError, RelationshipBehavior, ResolvedScene, SceneList, ScenePatch};
+use crate::{CachedSceneError, ResolvedScene, SceneList, ScenePatch};
 use bevy_asset::{Asset, AssetPath, AssetServer, Assets};
 use bevy_ecs::{
     bundle::Bundle,
@@ -10,7 +10,7 @@ use bevy_ecs::{
     system::IntoObserverSystem,
     template::{FnTemplate, FromTemplate, SceneEntityReference, Template, TemplateContext},
 };
-use core::{any::{Any, TypeId}, marker::PhantomData};
+use core::{any::TypeId, marker::PhantomData};
 use thiserror::Error;
 use variadics_please::all_tuples;
 
@@ -344,13 +344,6 @@ impl<
     ) -> Result<(), ResolveSceneError> {
         let template = scene.get_or_insert_template::<T>(context);
         (self.0)(template, context);
-        if TypeId::of::<T>() == TypeId::of::<RelationshipBehavior>() {
-            scene.relationship_behavior = Some(
-                *(&*template as &dyn Any)
-                    .downcast_ref::<RelationshipBehavior>()
-                    .unwrap(),
-            );
-        }
         Ok(())
     }
 }

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ResolvedSceneRoot, Scene, SceneList, SceneListPatch, ScenePatch, ScenePatchInstance,
-    SpawnSceneError,
+    self as bevy_scene, bsn, RelationshipBehavior, ResolvedSceneRoot, Scene, SceneList,
+    SceneListPatch, ScenePatch, ScenePatchInstance, SpawnSceneError,
 };
 use alloc::sync::Arc;
 use bevy_asset::{AssetEvent, AssetServer, Assets, Handle};
@@ -456,8 +456,10 @@ pub trait EntityWorldMutSceneExt {
     ///
     /// When a scene is resolved, it will replace and orphan the current entity's children.
     ///
-    /// To retain and extend existing children instead, insert [`RelationshipBehavior::Merge`] on
-    /// the entity before calling this method.
+    /// To retain and extend existing children instead, include [`RelationshipBehavior::Merge`] in
+    /// the scene, insert it on the entity, or use [`EntityWorldMutSceneExt::merge_scene`].
+    ///
+    /// If both the scene and entity specify a [`RelationshipBehavior`], the scene takes precedence.
     ///
     /// If resolving and spawning is successful, the entity will contain the full contents of the spawned scene.
     ///
@@ -479,6 +481,13 @@ pub trait EntityWorldMutSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     fn queue_apply_scene<S: Scene>(&mut self, scene: S);
+
+    /// Merges the given [`Scene`] into the current entity, retaining and extending existing related entities.
+    ///
+    /// This is equivalent to applying a scene that includes [`RelationshipBehavior::Merge`].
+    fn merge_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError> {
+        self.apply_scene((bsn! { RelationshipBehavior::Merge }, scene))
+    }
 }
 
 impl EntityWorldMutSceneExt for EntityWorldMut<'_> {
@@ -929,17 +938,42 @@ mod tests {
     }
 
     #[test]
-    fn apply_scene_with_merge_extends_children() {
+    fn merge_scene_extends_children() {
         let mut app = test_app();
         let world = app.world_mut();
 
         let pre_existing = world.spawn(PreExistingChild).id();
         let root = world.spawn(Name::new("root")).add_child(pre_existing).id();
 
-        assert_eq!(
-            world.entity(root).get::<Children>().map(Children::len),
-            Some(1)
+        let scene = bsn! {
+            Children [ #SceneChild SceneChild ]
+        };
+        world.entity_mut(root).merge_scene(scene).unwrap();
+
+        let children: Vec<Entity> = world
+            .entity(root)
+            .get::<Children>()
+            .map(|c| c.iter().collect())
+            .unwrap_or_default();
+
+        assert_eq!(children.len(), 2);
+        assert!(children.contains(&pre_existing));
+        assert!(
+            children
+                .iter()
+                .filter(|entity| world.entity(**entity).contains::<SceneChild>())
+                .count()
+                == 1
         );
+    }
+
+    #[test]
+    fn apply_scene_entity_merge_fallback_extends_children() {
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        let pre_existing = world.spawn(PreExistingChild).id();
+        let root = world.spawn(Name::new("root")).add_child(pre_existing).id();
 
         let scene = bsn! {
             Children [ #SceneChild SceneChild ]
@@ -958,12 +992,34 @@ mod tests {
 
         assert_eq!(children.len(), 2);
         assert!(children.contains(&pre_existing));
-        assert!(
-            children
-                .iter()
-                .filter(|entity| world.entity(**entity).contains::<SceneChild>())
-                .count()
-                == 1
-        );
+    }
+
+    #[test]
+    fn apply_scene_scene_behavior_overrides_entity() {
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        let pre_existing = world.spawn(PreExistingChild).id();
+        let root = world.spawn(Name::new("root")).add_child(pre_existing).id();
+
+        let scene = bsn! {
+            RelationshipBehavior::Overwrite
+            Children [ #SceneChild SceneChild ]
+        };
+        world
+            .entity_mut(root)
+            .insert(RelationshipBehavior::Merge)
+            .apply_scene(scene)
+            .unwrap();
+
+        let children: Vec<Entity> = world
+            .entity(root)
+            .get::<Children>()
+            .map(|c| c.iter().collect())
+            .unwrap_or_default();
+
+        assert_eq!(children.len(), 1);
+        assert!(!children.contains(&pre_existing));
+        assert!(world.entity(children[0]).contains::<SceneChild>());
     }
 }


### PR DESCRIPTION
# Objective

- Implements priority pattern "scene then entity then default" for `RelationshipBehavior` on `apply_scene`. 
- This would allow the scene to determine whether it should extend or overwrite children, which is a potentially valuable feature if...
    - Scene use of children needs to be consistent. 
    - Developer wants the to organize entity behavior predominantly through scenes. 
- This is one of the directions for extension of this feature mentioned in https://github.com/bevyengine/bevy/pull/24932 (draft notes).

## Solution

- The scene template 

## Testing

- See bottom of `spawn.rs`